### PR TITLE
Encapsulate javascript code

### DIFF
--- a/src/main/resources/io/jenkins/plugins/paranoia/DisableLoginAutocompleteDecorator/simple-footer.jelly
+++ b/src/main/resources/io/jenkins/plugins/paranoia/DisableLoginAutocompleteDecorator/simple-footer.jelly
@@ -26,7 +26,9 @@
 <j:jelly xmlns:j="jelly:core">
     <j:if test="${it.enabled}">
         <script>
-            document.querySelector("input[name='j_password']").setAttribute("autocomplete", "off");
+            (function() {
+                document.querySelector("input[name='j_password']").setAttribute("autocomplete", "off");
+            })()
         </script>
     </j:if>
 </j:jelly>


### PR DESCRIPTION
Prevent local variables from leaking. Not required with a oneline, but provide "structure" for future hack like that.